### PR TITLE
[KR-128] 좌표 기반의 숙소 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,13 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+	implementation 'org.hibernate:hibernate-spatial:6.6.8.Final'
+	// QueryDSL 추가
+	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 
 	// DB 관련
@@ -86,12 +93,6 @@ dependencies {
 	testImplementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-	// QueryDSL 추가
-	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
-	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	// API 문서화
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/controller/AccommodationGuestController.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/controller/AccommodationGuestController.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import java.io.IOException;
 import java.util.List;
+
+import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationCoordSearchRequest;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationRequest;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationResponse;
 import jsbh.Jusangbokhap.api.accommodation.service.AccommodationGuestService;
@@ -12,10 +14,7 @@ import jsbh.Jusangbokhap.api.search.service.SearchKeywordService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -37,6 +36,11 @@ public class AccommodationGuestController {
     public List<AccommodationResponse> search(@ParameterObject @ModelAttribute AccommodationRequest.Search search) throws IOException {
         keywordService.saveKeyword(search);
         return accommodationGuestService.find(search);
+    }
+
+    @GetMapping("/coordinate")
+    public List<AccommodationResponse> search(@RequestBody AccommodationCoordSearchRequest coordSearchRequest) {
+        return accommodationGuestService.findByCoordinate(coordSearchRequest);
     }
 
 }

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchRequest.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchRequest.java
@@ -1,0 +1,12 @@
+package jsbh.Jusangbokhap.api.accommodation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AccommodationCoordSearchRequest {
+
+    private Double longitude;
+    private Double latitude;
+    private Double radius;
+
+}

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchResponse.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchResponse.java
@@ -1,0 +1,7 @@
+package jsbh.Jusangbokhap.api.accommodation.dto;
+
+public class AccommodationCoordSearchResponse {
+
+
+
+}

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/mapper/AccommodationMapper.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/mapper/AccommodationMapper.java
@@ -7,15 +7,15 @@ import java.util.stream.Collectors;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationRequest.Create;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationResponse.Read;
 import jsbh.Jusangbokhap.api.availableDate.mapper.AvailableDateMapper;
-import jsbh.Jusangbokhap.domain.accommodation.Accommodation;
-import jsbh.Jusangbokhap.domain.accommodation.AccommodationAddress;
-import jsbh.Jusangbokhap.domain.accommodation.AccommodationPrice;
-import jsbh.Jusangbokhap.domain.accommodation.AccommodationType;
-import jsbh.Jusangbokhap.domain.accommodation.AccommodationCapacity;
+import jsbh.Jusangbokhap.domain.accommodation.*;
+import org.locationtech.jts.geom.Point;
 
 public class AccommodationMapper {
 
     public static Accommodation toEntity(Create request) {
+
+        Point coordinate = AccommodationCoordinate
+                .createCoordinate(request.longitude(), request.latitude());
 
         return Accommodation.builder()
 
@@ -28,8 +28,7 @@ public class AccommodationMapper {
                         .sigungu(request.sigungu())
                         .eupmyeondong(request.eupmyeondong())
                         .detail(request.detail())
-                        .longitude(request.longitude())
-                        .latitude(request.latitude())
+                        .coordinate(new AccommodationCoordinate(coordinate))
                         .build())
 
                 .accommodationPrice(AccommodationPrice.from(request.price()))
@@ -55,8 +54,8 @@ public class AccommodationMapper {
                 accommodation.getBusinessName(),
                 accommodation.getTitle(),
                 accommodation.getAddress().getFullAddress(),
-                accommodation.getAddress().getLongitude(),
-                accommodation.getAddress().getLatitude(),
+                accommodation.getAddress().getCoordinate().getCoordinate().getX(),
+                accommodation.getAddress().getCoordinate().getCoordinate().getY(),
                 accommodation.getDescription(),
                 accommodation.getAccommodationPrice().getPrice(),
                 accommodation.getAccommodationType().name(),

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/service/AccommodationGuestService.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/service/AccommodationGuestService.java
@@ -4,13 +4,17 @@ package jsbh.Jusangbokhap.api.accommodation.service;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import jakarta.transaction.Transactional;
+
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+
+import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationCoordSearchRequest;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationRequest;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationResponse;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationResponse.Search;
+import jsbh.Jusangbokhap.api.accommodation.mapper.AccommodationMapper;
 import jsbh.Jusangbokhap.domain.accommodation.Accommodation;
 import jsbh.Jusangbokhap.domain.accommodation.AccommodationType;
 import jsbh.Jusangbokhap.domain.accommodation.QAccommodation;
@@ -45,6 +49,23 @@ public class AccommodationGuestService {
         }
         return responses;
     }
+
+    public List<AccommodationResponse> findByCoordinate(AccommodationCoordSearchRequest coordSearchRequest) {
+
+        List<Accommodation> accommodations =
+                accommodationRepository.findAccommodationByCoordinate(coordSearchRequest.getLongitude(),
+                        coordSearchRequest.getLatitude(),
+                        coordSearchRequest.getRadius());
+
+        List<AccommodationResponse> responses = new ArrayList<>();
+
+        for (Accommodation accommodation : accommodations) {
+            responses.add(AccommodationMapper.toResponse(accommodation));
+        }
+
+        return responses;
+    }
+
 
     private Predicate buildPredicate(AccommodationRequest.Search filter) {
         BooleanBuilder builder = new BooleanBuilder();

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/service/AccommodationHostService.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/service/AccommodationHostService.java
@@ -14,6 +14,7 @@ import jsbh.Jusangbokhap.domain.accommodation.Accommodation;
 import jsbh.Jusangbokhap.domain.accommodation.repository.AccommodationRepository;
 import jsbh.Jusangbokhap.domain.availableDate.AvailableDate;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -90,7 +91,8 @@ public class AccommodationHostService {
 
     public AccommodationResponse.Address getAccommodationAddressById(Long accommodationId) {
         Accommodation accommodation = getAccommodationByAccommodationId(accommodationId);
-        return new Address(accommodation.getAddress().getLatitude(), accommodation.getAddress().getLatitude());
+        Point coordinate = accommodation.getAddress().getCoordinate().getCoordinate();
+        return new Address(coordinate.getX(), coordinate.getY());
     }
 
     //TODO 분리 예정

--- a/src/main/java/jsbh/Jusangbokhap/api/facility/service/FacilityService.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/facility/service/FacilityService.java
@@ -15,6 +15,7 @@ import jsbh.Jusangbokhap.domain.facility.FacilityCategory;
 import jsbh.Jusangbokhap.domain.facility.repository.FacilityRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -86,10 +87,13 @@ public class FacilityService {
 
     private List<Facility> updateFacilitiesForAccommodation(Accommodation accommodation,
                                                             List<FacilityCategory> categories, int radius) {
+
+        Point coordinate = accommodation.getAddress().getCoordinate().getCoordinate();
+
         List<FacilityResponse> responses = fetchNearbyFacilities(
                 categories,
-                accommodation.getAddress().getLongitude(),
-                accommodation.getAddress().getLatitude(),
+                coordinate.getX(),
+                coordinate.getY(),
                 radius)
                 .collectList()
                 .block();

--- a/src/main/java/jsbh/Jusangbokhap/domain/accommodation/Accommodation.java
+++ b/src/main/java/jsbh/Jusangbokhap/domain/accommodation/Accommodation.java
@@ -49,7 +49,7 @@ public class Accommodation extends BaseEntity {
     private String businessName;
 
     @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "accommodationAddress_id")
+    @JoinColumn(name = "accommodation_address_id")
     private AccommodationAddress address;
 
     @Column(nullable = false)

--- a/src/main/java/jsbh/Jusangbokhap/domain/accommodation/AccommodationAddress.java
+++ b/src/main/java/jsbh/Jusangbokhap/domain/accommodation/AccommodationAddress.java
@@ -1,10 +1,6 @@
 package jsbh.Jusangbokhap.domain.accommodation;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +16,7 @@ public class AccommodationAddress {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "accommodationAddress_id")
+    @Column(name = "accommodation_address_id")
     private Long id;
 
     private String sido;
@@ -31,9 +27,8 @@ public class AccommodationAddress {
 
     private String detail;
 
-    private Double longitude;
-
-    private Double latitude;
+    @Embedded
+    private AccommodationCoordinate coordinate;
 
     public String getFullAddress() {
         return sido + " " + sigungu + " " + eupmyeondong + " " + detail;
@@ -62,12 +57,8 @@ public class AccommodationAddress {
             this.detail = detail;
         }
 
-        if (longitude != null) {
-            this.longitude = longitude;
-        }
-
-        if (latitude != null) {
-            this.latitude = latitude;
+        if (longitude != null && latitude != null) {
+            this.coordinate.updateCoordinate(longitude,latitude);
         }
     }
 }

--- a/src/main/java/jsbh/Jusangbokhap/domain/accommodation/AccommodationCoordinate.java
+++ b/src/main/java/jsbh/Jusangbokhap/domain/accommodation/AccommodationCoordinate.java
@@ -1,0 +1,38 @@
+package jsbh.Jusangbokhap.domain.accommodation;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccommodationCoordinate {
+
+    private static final int SRID = 4326;
+
+    /**
+     * SRID(Spatial Reference Identifier)는 데이터 좌표계를 구분할 수 있는 식별 코드.
+     * 가장 흔하게 사용되는 값은 4326으로 위도(Latitude)와 경도(Longitude)를 사용하여 위치를 표현하는 WGS84 좌표계를 의미.
+     * 카카오맵에서도 해당 좌표계를 사용
+     */
+    @Column(columnDefinition = "geometry(Point, 4326)", nullable = false)
+    private Point coordinate;
+
+    public static Point createCoordinate(Double longitude, Double latitude) {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Point newPoint = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+        newPoint.setSRID(SRID);
+        return newPoint;
+    }
+
+    public void updateCoordinate(Double longitude, Double latitude) {
+        this.coordinate = createCoordinate(longitude, latitude);
+    }
+}

--- a/src/main/java/jsbh/Jusangbokhap/domain/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/jsbh/Jusangbokhap/domain/accommodation/repository/AccommodationRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import jsbh.Jusangbokhap.domain.accommodation.Accommodation;
 import jsbh.Jusangbokhap.domain.availableDate.AvailableDateStatus;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -50,5 +51,15 @@ public class AccommodationRepository {
                 .distinct()
                 .where(availableDate.status.eq(AvailableDateStatus.AVAILABLE), predicate)
                 .fetch();
+    }
+
+    public List<Accommodation> findAccommodationByCoordinate(Double longitude, Double latitude, Double radius) {
+        return em.createNativeQuery("SELECT a.* FROM accommodation a " +
+                        "JOIN accommodation_address ad ON a.accommodation_address_id = ad.accommodation_address_id " +
+                "WHERE ST_DWithin(ad.coordinate, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326), :radius)", Accommodation.class)
+                .setParameter("longitude", longitude)
+                .setParameter("latitude", latitude)
+                .setParameter("radius", radius)
+                .getResultList();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,12 +75,13 @@ server:
 ---
 spring:
   config:
+    import: optional:file:.env[.properties]
     activate:
       on-profile: dev
   datasource:
     url: jdbc:postgresql://localhost:5432/jusangbokhap
     username: postgres
-    password: postgres
+    password: 1234
     driver-class-name: org.postgresql.Driver
   data:
     mongodb:
@@ -94,6 +95,19 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
+
+elasticsearch:
+  custom:
+    host: ${ELASTICSEARCH_LOCAL_HOST}
+    port: ${ELASTICSEARCH_LOCAL_PORT}
+    username: ${ELASTICSEARCH_LOCAL_USERNAME}
+    password: ${ELASTICSEARCH_LOCAL_PASSWORD}
+    certificate: ${ELASTICSEARCH_LOCAL_CERTIFICATE}
 
 ---
 spring:
@@ -116,7 +130,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
 
 ---
 spring:
@@ -158,7 +176,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        dialect: org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
 
 management:
   endpoint:

--- a/src/test/java/jsbh/Jusangbokhap/api/facility/service/FacilityServiceTest.java
+++ b/src/test/java/jsbh/Jusangbokhap/api/facility/service/FacilityServiceTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import jsbh.Jusangbokhap.api.accommodation.service.AccommodationHostService;
 import jsbh.Jusangbokhap.domain.accommodation.Accommodation;
 import jsbh.Jusangbokhap.domain.accommodation.AccommodationAddress;
+import jsbh.Jusangbokhap.domain.accommodation.AccommodationCoordinate;
 import jsbh.Jusangbokhap.domain.facility.FacilityCategory;
 import jsbh.Jusangbokhap.domain.facility.repository.FacilityRepository;
 import okhttp3.HttpUrl;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Point;
 import org.springframework.web.reactive.function.client.WebClient;
 
 class FacilityServiceTest {
@@ -54,10 +56,11 @@ class FacilityServiceTest {
     void 시설_업데이트_개수_조회_성공_테스트() {
         Long accommodationId = 1L;
 
+        Point coordinate = AccommodationCoordinate.createCoordinate(100.0, 200.0);
+
         Accommodation dummyAccommodation = Accommodation.builder()
                 .address(AccommodationAddress.builder()
-                        .longitude(100.0)
-                        .latitude(200.0)
+                        .coordinate(new AccommodationCoordinate(coordinate))
                         .build())
                 .build();
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/kr-128 -> dev

### 이슈
- close #41 

### 작업 사항
- [x] 사용자는 경도(longitude-x), 위도(latitude-y), 반경(radius) 데이터를 갖고 숙소 조회를 요청할 수 있습니다.
- [x] 좌표 및 반경을 기반으로 숙소를 조회할 수 있습니다.

### 전달 사항 (없으면 제거)
좌표 및 반경 기반의 숙소 조회 성능이 매우 떨어집니다. 최적화를 진행해야 합니다.
