### PR TITLE
[KR-128] 좌표 기반의 숙소 조회 기능 성능 최적화 및 에러 수정

### DIFF
--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/controller/AccommodationGuestController.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/controller/AccommodationGuestController.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.List;
 
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationCoordSearchRequest;
+import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationCoordSearchResponse;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationRequest;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationResponse;
 import jsbh.Jusangbokhap.api.accommodation.service.AccommodationGuestService;
@@ -39,7 +40,7 @@ public class AccommodationGuestController {
     }
 
     @GetMapping("/coordinate")
-    public List<AccommodationResponse> search(@RequestBody AccommodationCoordSearchRequest coordSearchRequest) {
+    public List<AccommodationCoordSearchResponse> search(AccommodationCoordSearchRequest coordSearchRequest) {
         return accommodationGuestService.findByCoordinate(coordSearchRequest);
     }
 

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchRequest.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchRequest.java
@@ -1,12 +1,20 @@
 package jsbh.Jusangbokhap.api.accommodation.dto;
 
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class AccommodationCoordSearchRequest {
 
+    @NotNull
     private Double longitude;
+    @NotNull
     private Double latitude;
+    @NotNull
     private Double radius;
+    private Long lastAccommodationId;
+//    private int pageSize;
 
 }

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchResponse.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/dto/AccommodationCoordSearchResponse.java
@@ -1,7 +1,38 @@
 package jsbh.Jusangbokhap.api.accommodation.dto;
 
+import jsbh.Jusangbokhap.domain.accommodation.Accommodation;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class AccommodationCoordSearchResponse {
 
+    private String businessName;
+    private String title;
+    private String address;
+    private Integer price;
+    private String accommodationType;
 
+    @Builder
+    private AccommodationCoordSearchResponse(String businessName, String title, String address,
+                                             Integer price, String accommodationType) {
+        this.businessName = businessName;
+        this.title = title;
+        this.address = address;
+        this.price = price;
+        this.accommodationType = accommodationType;
+    }
+
+    public static AccommodationCoordSearchResponse of(Accommodation accommodation) {
+        return AccommodationCoordSearchResponse.builder()
+                .businessName(accommodation.getBusinessName())
+                .title(accommodation.getTitle())
+                .address(accommodation.getAddress().getFullAddress())
+                .price(accommodation.getAccommodationPrice().getPrice())
+                .accommodationType(accommodation.getAccommodationType().name())
+                .build();
+    }
 
 }

--- a/src/main/java/jsbh/Jusangbokhap/api/accommodation/service/AccommodationGuestService.java
+++ b/src/main/java/jsbh/Jusangbokhap/api/accommodation/service/AccommodationGuestService.java
@@ -3,7 +3,6 @@ package jsbh.Jusangbokhap.api.accommodation.service;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
-import jakarta.transaction.Transactional;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -11,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationCoordSearchRequest;
+import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationCoordSearchResponse;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationRequest;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationResponse;
 import jsbh.Jusangbokhap.api.accommodation.dto.AccommodationResponse.Search;
@@ -22,15 +22,16 @@ import jsbh.Jusangbokhap.domain.accommodation.repository.AccommodationRepository
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AccommodationGuestService {
 
     private final AccommodationRepository accommodationRepository;
 
-    @Transactional
     public List<AccommodationResponse> find(AccommodationRequest.Search filter) {
         Predicate predicate = buildPredicate(filter);
 
@@ -50,20 +51,18 @@ public class AccommodationGuestService {
         return responses;
     }
 
-    public List<AccommodationResponse> findByCoordinate(AccommodationCoordSearchRequest coordSearchRequest) {
+    public List<AccommodationCoordSearchResponse> findByCoordinate(AccommodationCoordSearchRequest coordSearchRequest) {
 
         List<Accommodation> accommodations =
                 accommodationRepository.findAccommodationByCoordinate(coordSearchRequest.getLongitude(),
                         coordSearchRequest.getLatitude(),
-                        coordSearchRequest.getRadius());
+                        coordSearchRequest.getRadius(),
+                        coordSearchRequest.getLastAccommodationId(),
+                        10);
 
-        List<AccommodationResponse> responses = new ArrayList<>();
-
-        for (Accommodation accommodation : accommodations) {
-            responses.add(AccommodationMapper.toResponse(accommodation));
-        }
-
-        return responses;
+        return accommodations.stream()
+                .map(AccommodationCoordSearchResponse::of)
+                .toList();
     }
 
 

--- a/src/main/java/jsbh/Jusangbokhap/domain/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/jsbh/Jusangbokhap/domain/accommodation/repository/AccommodationRepository.java
@@ -8,6 +8,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.persistence.Query;
 import jsbh.Jusangbokhap.domain.accommodation.Accommodation;
 import jsbh.Jusangbokhap.domain.availableDate.AvailableDateStatus;
 import org.locationtech.jts.geom.Point;
@@ -53,13 +55,30 @@ public class AccommodationRepository {
                 .fetch();
     }
 
-    public List<Accommodation> findAccommodationByCoordinate(Double longitude, Double latitude, Double radius) {
-        return em.createNativeQuery("SELECT a.* FROM accommodation a " +
-                        "JOIN accommodation_address ad ON a.accommodation_address_id = ad.accommodation_address_id " +
-                "WHERE ST_DWithin(ad.coordinate, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326), :radius)", Accommodation.class)
+    public List<Accommodation> findAccommodationByCoordinate(Double longitude, Double latitude, Double radius,
+                                                             Long lastAccommodationId, int pageSize) {
+
+        String query = "SELECT a.* FROM accommodation a" +
+                " JOIN accommodation_address ad ON a.accommodation_address_id = ad.accommodation_address_id" +
+                " WHERE ST_DWithin(ad.coordinate, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326), :radius, true)";
+
+        // 처음 조회하는 게 아니라면
+        if (lastAccommodationId != null) {
+            query += " AND a.accommodation_id > :lastAccommodationId";
+        }
+
+        query += " ORDER BY a.accommodation_id LIMIT :pageSize";
+
+        Query nativeQuery = em.createNativeQuery(query, Accommodation.class)
                 .setParameter("longitude", longitude)
                 .setParameter("latitude", latitude)
                 .setParameter("radius", radius)
-                .getResultList();
+                .setParameter("pageSize", pageSize);
+
+        if (lastAccommodationId != null) {
+            nativeQuery.setParameter("lastAccommodationId", lastAccommodationId);
+        }
+
+        return nativeQuery.getResultList();
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/kr-128 -> dev

### 작업 사항
- [x] 좌표 기반 숙소 조회 시, 응답 DTO 로 Mapping 되지 않는 문제를 해결했습니다.
- [x] Pagination 을 통해 좌표 기반 숙소 조회 성능을 최적화 했습니다.

### 전달 사항
좌표 기반으로 숙소를 검색하면 10개의 숙소 리스트가 응답됩니다.
추가 숙소 데이터가 필요하다면, 이전 조회 시 가장 마지막 숙소 id인 lastAccommodationId 값을 같이 넘기면 됩니다.
